### PR TITLE
Add notebook command to mdxe

### DIFF
--- a/packages/mdxe/README.md
+++ b/packages/mdxe/README.md
@@ -53,6 +53,22 @@ mdxe start
 mdxe lint
 ```
 
+### Notebook Command
+
+Open an individual notebook in the embedded app. Use `--save` to upload the file
+to Payload CMS or `--load` to download it before starting.
+
+```bash
+# View a notebook
+mdxe notebook notes/example.mdx
+
+# Load the notebook from Payload CMS then open it
+mdxe notebook notes/example.mdx --load
+
+# Save local changes back to Payload CMS
+mdxe notebook notes/example.mdx --save
+```
+
 ## Configuration
 
 MDXE works with zero configuration, but you can customize it by creating the following files:

--- a/packages/mdxe/src/app/page.tsx
+++ b/packages/mdxe/src/app/page.tsx
@@ -3,6 +3,19 @@ import { MDXRemote } from 'next-mdx-remote/rsc'
 import fs from 'fs/promises'
 
 export default async function Page() {
+  if (process.env.NOTEBOOK_PATH) {
+    try {
+      const content = await fs.readFile(process.env.NOTEBOOK_PATH, 'utf-8')
+      return (
+        <article className="prose prose-slate max-w-none p-4">
+          <MDXRemote source={content} />
+        </article>
+      )
+    } catch (e) {
+      console.error('Error reading notebook:', e)
+    }
+  }
+
   if (process.env.README_PATH) {
     try {
       const content = await fs.readFile(process.env.README_PATH, 'utf-8')


### PR DESCRIPTION
## Summary
- add `notebook` subcommand to `mdxe` CLI
- allow saving/loading notebooks through Payload CMS
- expose NOTEBOOK_PATH for embedded app
- document notebook command in README

## Testing
- `pnpm -r test`