### PR TITLE
Implement basic NotebookCell component

### DIFF
--- a/packages/mdxe/package.json
+++ b/packages/mdxe/package.json
@@ -39,6 +39,8 @@
     "nextra": "^4.2.17",
     "nextra-theme-docs": "^4.2.17",
     "null-loader": "^4.0.1",
+    "@monaco-editor/react": "^4.7.0",
+    "jest-lite": "^1.0.0-alpha.4",
     "payload": "^2.32.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/mdxe/src/app/[...slug]/page.tsx
+++ b/packages/mdxe/src/app/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 import fs from 'fs/promises'
+import { useMDXComponents } from '../mdx-components'
 import path from 'path'
 import { resolvePath, isMarkdownFile, getAllMarkdownFiles } from '../../utils/file-resolution'
 
@@ -73,7 +74,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   
   return (
     <article className="prose prose-slate max-w-7xl mx-auto p-4">
-      <MDXRemote source={content} />
+      <MDXRemote source={content} components={useMDXComponents({})} />
     </article>
   )
 }

--- a/packages/mdxe/src/app/components/NotebookCell.tsx
+++ b/packages/mdxe/src/app/components/NotebookCell.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import Editor from '@monaco-editor/react'
+
+export interface NotebookCellProps {
+  code: string
+  language?: string
+  meta?: Record<string, any>
+}
+
+export default function NotebookCell({ code: initialCode, language = 'javascript', meta = {} }: NotebookCellProps) {
+  const [code, setCode] = useState(initialCode)
+  const [output, setOutput] = useState('')
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) return
+
+    const doc = iframe.contentDocument!
+    doc.open()
+    doc.write(`<!DOCTYPE html><html><body><div id="out"></div>
+      <script src="https://unpkg.com/jest-lite@1.0.0-alpha.4/dist/core.js"></script>
+      <script src="https://unpkg.com/jest-lite@1.0.0-alpha.4/dist/prettify.js"></script>
+      <script>
+      window.addEventListener('message', (e) => {
+        const { code, test } = e.data;
+        try {
+          const result = eval(code);
+          if (test && window.jestLite) {
+            const results = window.jestLite.run();
+            const html = window.jestLite.prettify.toHTML(results);
+            parent.postMessage({ html }, '*');
+          } else {
+            parent.postMessage({ result: result === undefined ? '' : String(result) }, '*');
+          }
+        } catch (err) {
+          parent.postMessage({ error: err.message }, '*');
+        }
+      });
+      </script></body></html>`)
+    doc.close()
+  }, [])
+
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data.html) setOutput(e.data.html)
+      else if (e.data.error) setOutput('Error: ' + e.data.error)
+      else if (e.data.result !== undefined) setOutput(String(e.data.result))
+    }
+    window.addEventListener('message', handler)
+    return () => window.removeEventListener('message', handler)
+  }, [])
+
+  const run = () => {
+    iframeRef.current?.contentWindow?.postMessage({ code, test: meta.test }, '*')
+  }
+
+  return (
+    <div className='notebook-cell my-4'>
+      <Editor height='200px' defaultLanguage={language} value={code} onChange={(v) => setCode(v || '')} />
+      <button className='mt-2 px-2 py-1 border rounded' onClick={run}>Run</button>
+      <div className='mt-2' dangerouslySetInnerHTML={{ __html: output }} />
+      <iframe ref={iframeRef} sandbox='allow-scripts' style={{ display: 'none' }} />
+    </div>
+  )
+}

--- a/packages/mdxe/src/app/components/parseMeta.ts
+++ b/packages/mdxe/src/app/components/parseMeta.ts
@@ -1,0 +1,11 @@
+export function parseMeta(meta?: string): Record<string, any> {
+  const result: Record<string, any> = {}
+  if (!meta) return result
+  const parts = meta.split(/\s+/)
+  for (const part of parts) {
+    const [k, v] = part.split('=')
+    if (v === undefined) result[k] = true
+    else result[k] = v.replace(/^"|"$/g, '')
+  }
+  return result
+}

--- a/packages/mdxe/src/app/mdx-components.tsx
+++ b/packages/mdxe/src/app/mdx-components.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import type { ComponentType } from 'react'
+import NotebookCell from './components/NotebookCell'
+import { parseMeta } from './components/parseMeta'
 
 type MDXComponents = Record<string, ComponentType<React.ComponentProps<any>>>
 
@@ -30,9 +32,18 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     p: ({ children }: { children: React.ReactNode }) => <p className="my-2">{children}</p>,
   }
 
+  const NotebookPre = ({ children }: { children: React.ReactElement }) => {
+    if (!React.isValidElement(children)) return <pre>{children}</pre>
+    const { className = '', children: code, ['data-meta']: meta } = children.props as any
+    const language = className.replace('language-', '')
+    const metaObj = parseMeta(meta)
+    return <NotebookCell code={(code as string).trim()} language={language} meta={metaObj} />
+  }
+
   return {
     ...defaultComponents,
     ...layouts,
+    pre: NotebookPre,
     ...userComponents,
     ...components,
   }

--- a/packages/mdxe/src/app/page.tsx
+++ b/packages/mdxe/src/app/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 import fs from 'fs/promises'
+import { useMDXComponents } from './mdx-components'
 
 export default async function Page() {
   if (process.env.README_PATH) {
@@ -8,7 +9,7 @@ export default async function Page() {
       const content = await fs.readFile(process.env.README_PATH, 'utf-8')
       return (
         <article className="prose prose-slate max-w-none p-4">
-          <MDXRemote source={content} />
+          <MDXRemote source={content} components={useMDXComponents({})} />
         </article>
       )
     } catch (e) {


### PR DESCRIPTION
## Summary
- add NotebookCell with Monaco editor and sandboxed iframe
- parse code block meta and map fenced code to NotebookCell
- use custom MDX components in notebook pages
- declare new dependencies for editing and tests

## Testing
- `pnpm --filter mdxe test` *(fails: Command failed: pnpm build)*